### PR TITLE
Use ceil instead of // for initial scale factor

### DIFF
--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -23,7 +23,7 @@ class USDUpscaler():
     def __init__(self, p, image, upscaler_index:int, save_redraw, save_seams_fix, tile_size) -> None:
         self.p:StableDiffusionProcessing = p
         self.image:Image = image
-        self.scale_factor = max(p.width, p.height) // max(image.width, image.height)
+        self.scale_factor = math.ceil(max(p.width, p.height) / max(image.width, image.height))
         self.upscaler = shared.sd_upscalers[upscaler_index]
         self.redraw = USDURedraw()
         self.redraw.save = save_redraw


### PR DESCRIPTION
When computing the initial scale factor `//` is used, which forces a scale factor of `1` for any destination resolution less than twice the original. This prevent the upscaler to be used, and uses a basic resize instead, having less detail in the final image.

I propose the use of `math.ceil` to always select the upper factor needed.

Note : this is most useful for smaller ratios like `1.5`, but could be detrimental for higher factors, TBD. We could maybe add a condition to only use ceil for factors < 2.