### PR TITLE
Tile width and height instead of a single dimension

### DIFF
--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -34,8 +34,8 @@ class USDUpscaler():
         self.seams_fix.tile_width = tile_width if tile_width > 0 else tile_height
         self.seams_fix.tile_height = tile_height if tile_height > 0 else tile_width
         self.initial_info = None
-        self.rows = math.ceil(self.p.height / (tile_height if tile_height > 0 else tile_width))
-        self.cols = math.ceil(self.p.width / (tile_width if tile_width > 0 else tile_height))
+        self.rows = math.ceil(self.p.height / self.redraw.tile_height)
+        self.cols = math.ceil(self.p.width / self.redraw.tile_width)
 
     def get_factor(self, num):
         # Its just return, don't need elif
@@ -506,7 +506,7 @@ class Script(scripts.Script):
                 upscaler_index, save_upscaled_image, redraw_mode, save_seams_fix_image, seams_fix_mask_blur,
                 seams_fix_type, target_size_type, custom_width, custom_height, custom_scale]
 
-    def run(self, p, _, tile_width, tile_heiht, mask_blur, padding, seams_fix_width, seams_fix_denoise, seams_fix_padding,
+    def run(self, p, _, tile_width, tile_height, mask_blur, padding, seams_fix_width, seams_fix_denoise, seams_fix_padding,
             upscaler_index, save_upscaled_image, redraw_mode, save_seams_fix_image, seams_fix_mask_blur,
             seams_fix_type, target_size_type, custom_width, custom_height, custom_scale):
 
@@ -537,7 +537,7 @@ class Script(scripts.Script):
             p.height = math.ceil((init_img.height * custom_scale) / 64) * 64
 
         # Upscaling
-        upscaler = USDUpscaler(p, init_img, upscaler_index, save_upscaled_image, save_seams_fix_image, tile_width, tile_heiht)
+        upscaler = USDUpscaler(p, init_img, upscaler_index, save_upscaled_image, save_seams_fix_image, tile_width, tile_height)
         upscaler.upscale()
         
         # Drawing

--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -27,15 +27,15 @@ class USDUpscaler():
         self.upscaler = shared.sd_upscalers[upscaler_index]
         self.redraw = USDURedraw()
         self.redraw.save = save_redraw
-        self.redraw.tile_width = tile_width
-        self.redraw.tile_height = tile_height
+        self.redraw.tile_width = tile_width if tile_width > 0 else tile_height
+        self.redraw.tile_height = tile_height if tile_height > 0 else tile_width
         self.seams_fix = USDUSeamsFix()
         self.seams_fix.save = save_seams_fix
-        self.seams_fix.tile_width = tile_width
-        self.seams_fix.tile_height = tile_height
+        self.seams_fix.tile_width = tile_width if tile_width > 0 else tile_height
+        self.seams_fix.tile_height = tile_height if tile_height > 0 else tile_width
         self.initial_info = None
-        self.rows = math.ceil(self.p.height / tile_height)
-        self.cols = math.ceil(self.p.width / tile_width)
+        self.rows = math.ceil(self.p.height / (tile_height if tile_height > 0 else tile_width))
+        self.cols = math.ceil(self.p.width / (tile_width if tile_width > 0 else tile_height))
 
     def get_factor(self, num):
         # Its just return, don't need elif
@@ -112,6 +112,7 @@ class USDUpscaler():
         state.job_count = redraw_job_count + seams_job_count
 
     def print_info(self):
+        print(f"Tile size: {self.redraw.tile_width}x{self.redraw.tile_height}")
         print(f"Tiles amount: {self.rows * self.cols}")
         print(f"Grid: {self.rows}x{self.cols}")
         print(f"Redraw enabled: {self.redraw.enabled}")
@@ -454,8 +455,8 @@ class Script(scripts.Script):
                                 value=shared.sd_upscalers[0].name, type="index")
         with gr.Row():
             redraw_mode = gr.Dropdown(label="Type", choices=[k for k in redrow_modes], type="index", value=next(iter(redrow_modes)))
-            tile_width = gr.Slider(minimum=256, maximum=2048, step=64, label='Tile width', value=512)
-            tile_height = gr.Slider(minimum=256, maximum=2048, step=64, label='Tile height', value=512)
+            tile_width = gr.Slider(minimum=0, maximum=2048, step=64, label='Tile width', value=512)
+            tile_height = gr.Slider(minimum=0, maximum=2048, step=64, label='Tile height', value=0)
             mask_blur = gr.Slider(label='Mask blur', minimum=0, maximum=64, step=1, value=8)
             padding = gr.Slider(label='Padding', minimum=0, maximum=128, step=1, value=32)
         gr.HTML("<p style=\"margin-bottom:0.75em\">Seams fix:</p>")

--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -244,11 +244,11 @@ class USDUSeamsFix():
 
     def init_draw(self, p):
         self.initial_info = None
-        p.width = math.ceil((self.tile_size+self.padding) / 64) * 64
-        p.height = math.ceil((self.tile_size+self.padding) / 64) * 64
+        p.width = math.ceil((self.tile_width+self.padding) / 64) * 64
+        p.height = math.ceil((self.tile_height+self.padding) / 64) * 64
 
     def half_tile_process(self, p, image, rows, cols):
-        
+
         self.init_draw(p)
         processed = None
 
@@ -257,7 +257,7 @@ class USDUSeamsFix():
         row_gradient.paste(gradient.resize(
             (self.tile_size, self.tile_size//2), resample=Image.BICUBIC), (0, 0))
         row_gradient.paste(gradient.rotate(180).resize(
-                (self.tile_size, self.tile_size//2), resample=Image.BICUBIC), 
+                (self.tile_size, self.tile_size//2), resample=Image.BICUBIC),
                 (0, self.tile_size//2))
         col_gradient = Image.new("L", (self.tile_size, self.tile_size), "black")
         col_gradient.paste(gradient.rotate(90).resize(
@@ -346,7 +346,7 @@ class USDUSeamsFix():
         return fixed_image
 
     def band_pass_process(self, p, image, cols, rows):
-        
+
         self.init_draw(p)
         processed = None
 
@@ -361,7 +361,7 @@ class USDUSeamsFix():
         row_gradient = mirror_gradient.resize((image.width, self.width), resample=Image.BICUBIC)
         col_gradient = mirror_gradient.rotate(90).resize((self.width, image.height), resample=Image.BICUBIC)
 
-        for xi in range(1, cols):
+        for xi in range(1, rows):
             if state.interrupted:
                     break
             p.width = self.width + self.padding * 2
@@ -369,14 +369,14 @@ class USDUSeamsFix():
             p.inpaint_full_res = True
             p.inpaint_full_res_padding = self.padding
             mask = Image.new("L", (image.width, image.height), "black")
-            mask.paste(col_gradient, (xi * self.tile_size - self.width // 2, 0))
+            mask.paste(col_gradient, (xi * self.tile_width - self.width // 2, 0))
 
             p.init_images = [image]
             p.image_mask = mask
             processed = processing.process_images(p)
             if (len(processed.images) > 0):
                 image = processed.images[0]
-        for yi in range(1, rows):
+        for yi in range(1, cols):
             if state.interrupted:
                     break
             p.width = image.width
@@ -384,7 +384,7 @@ class USDUSeamsFix():
             p.inpaint_full_res = True
             p.inpaint_full_res_padding = self.padding
             mask = Image.new("L", (image.width, image.height), "black")
-            mask.paste(row_gradient, (0, yi * self.tile_size - self.width // 2))
+            mask.paste(row_gradient, (0, yi * self.tile_height - self.width // 2))
 
             p.init_images = [image]
             p.image_mask = mask

--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -314,7 +314,7 @@ class USDUSeamsFix():
         processed = None
         self.init_draw(p)
         gradient = Image.radial_gradient("L").resize(
-            (self.tile_size, self.tile_size), resample=Image.BICUBIC)
+            (self.tile_width, self.tile_height), resample=Image.BICUBIC)
         gradient = ImageOps.invert(gradient)
         p.denoising_strength = self.denoise
         #p.mask_blur = 0
@@ -324,13 +324,13 @@ class USDUSeamsFix():
             for xi in range(cols-1):
                 if state.interrupted:
                     break
-                p.width = self.tile_size
-                p.height = self.tile_size
+                p.width = self.tile_width
+                p.height = self.tile_height
                 p.inpaint_full_res = True
                 p.inpaint_full_res_padding = 0
                 mask = Image.new("L", (fixed_image.width, fixed_image.height), "black")
-                mask.paste(gradient, (xi*self.tile_size + self.tile_size//2,
-                                      yi*self.tile_size + self.tile_size//2))
+                mask.paste(gradient, (xi*self.tile_width + self.tile_width//2,
+                                      yi*self.tile_height + self.tile_height//2))
 
                 p.init_images = [fixed_image]
                 p.image_mask = mask

--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -253,17 +253,17 @@ class USDUSeamsFix():
         processed = None
 
         gradient = Image.linear_gradient("L")
-        row_gradient = Image.new("L", (self.tile_size, self.tile_size), "black")
+        row_gradient = Image.new("L", (self.tile_width, self.tile_height), "black")
         row_gradient.paste(gradient.resize(
-            (self.tile_size, self.tile_size//2), resample=Image.BICUBIC), (0, 0))
+            (self.tile_width, self.tile_height//2), resample=Image.BICUBIC), (0, 0))
         row_gradient.paste(gradient.rotate(180).resize(
-                (self.tile_size, self.tile_size//2), resample=Image.BICUBIC),
-                (0, self.tile_size//2))
-        col_gradient = Image.new("L", (self.tile_size, self.tile_size), "black")
+                (self.tile_width, self.tile_height//2), resample=Image.BICUBIC),
+                (0, self.tile_height//2))
+        col_gradient = Image.new("L", (self.tile_width, self.tile_height), "black")
         col_gradient.paste(gradient.rotate(90).resize(
-            (self.tile_size//2, self.tile_size), resample=Image.BICUBIC), (0, 0))
+            (self.tile_width//2, self.tile_height), resample=Image.BICUBIC), (0, 0))
         col_gradient.paste(gradient.rotate(270).resize(
-            (self.tile_size//2, self.tile_size), resample=Image.BICUBIC), (self.tile_size//2, 0))
+            (self.tile_width//2, self.tile_height), resample=Image.BICUBIC), (self.tile_width//2, 0))
 
         p.denoising_strength = self.denoise
         p.mask_blur = self.mask_blur
@@ -272,12 +272,12 @@ class USDUSeamsFix():
             for xi in range(cols):
                 if state.interrupted:
                     break
-                p.width = self.tile_size
-                p.height = self.tile_size
+                p.width = self.tile_width
+                p.height = self.tile_height
                 p.inpaint_full_res = True
                 p.inpaint_full_res_padding = self.padding
                 mask = Image.new("L", (image.width, image.height), "black")
-                mask.paste(row_gradient, (xi*self.tile_size, yi*self.tile_size + self.tile_size//2))
+                mask.paste(row_gradient, (xi*self.tile_width, yi*self.tile_height + self.tile_height//2))
 
                 p.init_images = [image]
                 p.image_mask = mask
@@ -289,12 +289,12 @@ class USDUSeamsFix():
             for xi in range(cols-1):
                 if state.interrupted:
                     break
-                p.width = self.tile_size
-                p.height = self.tile_size
+                p.width = self.tile_width
+                p.height = self.tile_height
                 p.inpaint_full_res = True
                 p.inpaint_full_res_padding = self.padding
                 mask = Image.new("L", (image.width, image.height), "black")
-                mask.paste(col_gradient, (xi*self.tile_size+self.tile_size//2, yi*self.tile_size))
+                mask.paste(col_gradient, (xi*self.tile_width+self.tile_width//2, yi*self.tile_height))
 
                 p.init_images = [image]
                 p.image_mask = mask


### PR DESCRIPTION
I altered the tile size input to prompt for width and height. As it is sometimes better to have a non 1:1 ratio when upscaling. Either to save VRAM, to avoid artifacts, or to do a single upscale pass with one tile.

If width or height is zero, the other dimension is used. 

When using 1:1 ratio, the script behaves exactly the same as before. By default the height is set to `0` so it won't change the default behavior to current users. 

Cf. feature request  #15 .