### PR TITLE
fix: disable batching

### DIFF
--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -522,6 +522,8 @@ class Script(scripts.Script):
         p.inpaint_full_res = False
 
         p.inpainting_fill = 1
+        p.n_iter = 1
+        p.batch_size = 1
 
         seed = p.seed
 


### PR DESCRIPTION
Batching is not currently supported in the master branch, as it processes each tile sequentially and always output 1 image per tile, regardless of batch count/size. 

So batching should be disabled, to avoid wasting resources.

This is noted in #23 