### PR TITLE
Changed padding max from 128 to 512 to help prevent artifacts during upscaling

### DIFF
--- a/scripts/ultimate-upscale.py
+++ b/scripts/ultimate-upscale.py
@@ -461,7 +461,7 @@ class Script(scripts.Script):
             tile_width = gr.Slider(minimum=0, maximum=2048, step=64, label='Tile width', value=512)
             tile_height = gr.Slider(minimum=0, maximum=2048, step=64, label='Tile height', value=0)
             mask_blur = gr.Slider(label='Mask blur', minimum=0, maximum=64, step=1, value=8)
-            padding = gr.Slider(label='Padding', minimum=0, maximum=128, step=1, value=32)
+            padding = gr.Slider(label='Padding', minimum=0, maximum=512, step=1, value=32)
         gr.HTML("<p style=\"margin-bottom:0.75em\">Seams fix:</p>")
         with gr.Row():
             seams_fix_type = gr.Dropdown(label="Type", choices=[k for k in seams_fix_types], type="index", value=next(iter(seams_fix_types)))


### PR DESCRIPTION
Hi, I've got a small change. I increased the max padding from 128 to 512.

I've had great success with upscaling with Ultimate SD Upscale and ControlNET tile. However, sometimes when using a high denoise, there are some minor artifacts popping up (small copies of the original prompt).

I was able to address this issue by increasing the padding to 256, above the current 128 limit. It might take some time, but it heavely reduced strange things popping up, when using a higher denoise.

Thanks for this great extension btw, and have a good weekend.
